### PR TITLE
[TASK] Refresh namespace urls in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ slashes also count!):
 {namespace v=FluidTYPO3\Vhs\ViewHelpers}
 <?xml version="1.0" encoding="UTF-8" ?>
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en"
-	  xmlns:v="http://fedext.net/ns/vhs/ViewHelpers"
+	  xmlns:v="http://typo3.org/ns/FluidTYPO3/Vhs/ViewHelpers"
 	  xmlns:f="http://typo3.org/ns/TYPO3/Fluid/ViewHelpers">
 	<head>
 		<f:layout name="Default" />
@@ -115,7 +115,7 @@ used. If your particular IDE does not require this approach, you should be able 
 ```html
 {namespace v=FluidTYPO3\Vhs\ViewHelpers}
 <div xmlns="http://www.w3.org/1999/xhtml" lang="en"
-	  xmlns:v="http://fedext.net/ns/vhs/ViewHelpers"
+	  xmlns:v="http://typo3.org/ns/FluidTYPO3/Vhs/ViewHelpers"
 	  xmlns:f="http://typo3.org/ns/TYPO3/Fluid/ViewHelpers">
 	<!-- Fluid goes here -->
 </div>
@@ -140,7 +140,7 @@ And construct the Partial template itself as such:
 {namespace v=FluidTYPO3\Vhs\ViewHelpers}
 <?xml version="1.0" encoding="UTF-8" ?>
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en"
-	  xmlns:v="http://fedext.net/ns/vhs/ViewHelpers"
+	  xmlns:v="http://typo3.org/ns/FluidTYPO3/Vhs/ViewHelpers"
 	  xmlns:f="http://typo3.org/ns/TYPO3/Fluid/ViewHelpers">
 	<head>
 		<title>Partials: MyPartial</title>
@@ -208,23 +208,18 @@ You do not have to inject the Service in order to use it - but it does have to b
 <?xml version="1.0" encoding="UTF-8" ?>
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en"
 	  xmlns:f="http://typo3.org/ns/TYPO3/Fluid/ViewHelpers"
-	  xmlns:flux="http://fedext.net/ns/flux/ViewHelpers"
-	  xmlns:fed="http://fedext.net/ns/fed/ViewHelpers"
-	  xmlns:dialog="http://fedext.net/ns/dialog/ViewHelpers"
-	  xmlns:notify="http://fedext.net/ns/notify/ViewHelpers"
-	  xmlns:v="http://fedext.net/ns/vhs/ViewHelpers"
-	  xmlns:w="http://fedext.net/ns/fluidwidget/ViewHelpers"
+	  xmlns:flux="http://typo3.org/ns/FluidTYPO3/Flux/ViewHelpers"
+	  xmlns:v="http://typo3.org/ns/FluidTYPO3/Vhs/ViewHelpers"
+	  xmlns:w="http://typo3.org/ns/fluidwidget"
 	/>
 ```
 
-Note: The following schemas are available for download (use "save page as") at the URLs used in the namespaces:
+Note: The following schemas are available for download (use "save page as"):
 
-* http://fedext.net/ns/flux/ViewHelpers
-* http://fedext.net/ns/fed/ViewHelpers
-* http://fedext.net/ns/vhs/ViewHelpers
-* http://fedext.net/ns/fluidwidget/ViewHelpers
-* http://fedext.net/ns/dialog/ViewHelpers
-* http://fedext.net/ns/notify/ViewHelpers
+* [http://typo3.org/ns/TYPO3/Fluid/ViewHelpers](https://fluidtypo3.org/schemas/fluid-master.xsd)
+* [http://typo3.org/ns/FluidTYPO3/Flux/ViewHelpers](https://fluidtypo3.org/schemas/flux-master.xsd)
+* [http://typo3.org/ns/FluidTYPO3/Vhs/ViewHelpers](https://fluidtypo3.org/schemas/vhs-master.xsd)
+* [http://typo3.org/ns/fluidwidget](https://fluidtypo3.org/schemas/fluidwidget-master.xsd)
 
 These schemas all apply to the very latest master versions of each extension's ViewHelpers - if you require an XSD for an earlier
 version which you currently have installed, simply generate an XSD from that TYPO3 installation and use the same namespace URL.


### PR DESCRIPTION
- Use the official namespaces
- Remove obsolete extensions/namespaces
- Add schema download links

I'm not really sure about the fluidwidget stuff. Should it be dropped?