### PR TITLE
[FEATURE] Only allow extkeys w/ vendor prefix

### DIFF
--- a/Classes/Service/SchemaService.php
+++ b/Classes/Service/SchemaService.php
@@ -158,6 +158,10 @@ class SchemaService implements SingletonInterface {
 	 * @throws \RuntimeException
 	 */
 	public function generateXsd($extensionKey, $xsdNamespace, $enablePhpTypes, $enableDocumentation = TRUE) {
+		if(strpos($extensionKey, ".") === FALSE) {
+			throw new \RuntimeException(sprintf('Please supply the extension key including the vendor prefix. E.g., instead of "flux", use "FluidTYPO3.flux". Provided value was "%s".', $extensionKey));
+		}
+
 		$classNames = $this->getClassNamesInExtension($extensionKey);
 		if (count($classNames) === 0) {
 			throw new \RuntimeException(sprintf('No ViewHelpers found in namespace "%s"', $extensionKey), 1330029328);

--- a/README.md
+++ b/README.md
@@ -69,7 +69,13 @@ DESCRIPTION:
 Execution:
 
 ```bash
-me@localhost:~/documentroot $ ./typo3/cli_dispatch.phpsh extbase schema:generate my_extkey "http://my.domain/namespace" > me.xsd
+me@localhost:~/documentroot $ ./typo3/cli_dispatch.phpsh extbase schema:generate vendor_prefix.my_extkey "http://my.domain/namespace" > me.xsd
+```
+
+or a more concrete example
+
+```bash
+me@localhost:~/documentroot $ ./typo3/cli_dispatch.phpsh extbase schema:generate FluidTYPO3.flux "http://my.domain/namespace" > me.xsd
 ```
 
 ...which will generate an XSD schema for all ViewHelpers in extension key (not ExtensionName!) "my_extkey", with the XSD namespace


### PR DESCRIPTION
It does not seem like schemaker currently supports
omitting the vendor prefix, at least in TYPO3 v7.6.
As such, make sure that its always supplied, since
weird errors appear otherwise.
