### PR TITLE
[TASK] Schemaker needs vhs 2.4.0 for T3 >= 7.3

### DIFF
--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -35,7 +35,7 @@ $EM_CONF[$_EXTKEY] = array(
 			'typo3' => '7.6.0-7.6.99',
 			'extbase' => '',
 			'fluid' => '',
-			'vhs' => '',
+			'vhs' => '2.4.0-0.0.0',
 		),
 		'conflicts' => array(
 		),


### PR DESCRIPTION
This is due to the template compilation change
described in https://github.com/FluidTYPO3/vhs/commit/27c85fd474132633587178a38cc9198d52bf50f9
If an older version of vhs is used, it'll simply
fail to display anything.